### PR TITLE
Making the component bind down, actions up

### DIFF
--- a/addon/components/ember-ckeditor.js
+++ b/addon/components/ember-ckeditor.js
@@ -1,23 +1,130 @@
-/* globals CKEDITOR */
 import Ember from 'ember';
 import layout from '../templates/components/ember-ckeditor';
 
 export default Ember.Component.extend({
   layout: layout,
-
-  _editor: null,
   'on-change': null,
 
-  didInsertElement() {
-    let textarea = this.element.querySelector('.editor');
-    let editor = this._editor = CKEDITOR.replace(textarea);
-    editor.on('change', (e) => {
-      this.sendAction('on-change', e.editor.getData());
-    });
-  },
+  /**
+   * CK Editor Instance
+   */
+  _editor: null,
+  /**
+   * Primary value. Bindable.
+   * Still have a bit of magic to ensure events are fired when they should be
+   */
+  value: null,
+  /**
+   * Ferries any bound-in values into the editor.
+   */
+  _handleValueChange: Ember.observer('value', function () {
+    if (this._editorChanging) {
+      return;
+    }
+    if (this._editor) {
+      this._editor.setData(this.get('value'));
+    }
+  }),
 
-  willDestroyElement() {
-    this._editor.destroy();
-    this._editor = null;
+  /**
+   * Skin that should be loaded.
+   * Not Bindable.
+   */
+  skin: 'moono',
+  /**
+   * The content tags that are permitted in the editor. Null/default will let the plugins configure.
+   * Note: If you remove the toolbar, you cannot use automatic content, and MUST specify it.
+   * Not Bindable.
+   */
+  allowedContent: null,
+  /**
+   * The content tags that are not permitted, even if the auto-config says they're available.
+   * Not Bindable.
+   */
+  disallowedContent: null,
+  /**
+   * ReadOnly mode
+   */
+  readOnly: false,
+  /**
+   * Build the config passed to ckeditor's init method
+   * Ideal for over-writing in sub-classes
+   * @returns {} ckeditor config
+   */
+  buildConfig: function () {
+    var config = {
+      skin: this.get('skin'),
+      disallowedContent: this.get('disallowedContent'),
+      readOnly: this.get('readOnly'),
+      allowedContent: this.get('allowedContent')
+    };
+
+    return config;
+  },
+  _handleDidInsertElement: Ember.on('didInsertElement', function () {
+    var editor = this._editor = this.$().ckeditor(this.buildConfig(), () => {
+      if (editor !== this._editor) {
+        //It's possible that the view re-rendered prior to the editor finished initializing.
+        //If so, destroy this editor.
+        editor.destroy(true);
+      } else {
+        editor.setData(this.get('value'), () => {
+          this.trigger('editor-ready');
+        });
+      }
+    }).editor;
+    this._editor.on('change', this._handleChange.bind(this));
+  }),
+  _handleWillClearRender: Ember.on('willClearRender', function () {
+    if (this._editor) {
+      if (this._editor.status === 'ready') {
+        //We can only destroy an editor that is ready.
+        //We check for orphaned editors in the insertElement callback
+        this._editor.destroy(true);
+      }
+      this._editor = null;
+    }
+  }),
+  /**
+   * Handles ckeditor change events, props them into the value object, sends actions and events.
+   * @param event
+   * @private
+   */
+  _handleChange: function (event) {
+    //We set a flag so we can disregard changes to 'value'
+    this._editorChanging = true;
+    try {
+      var newValue = event.editor.getData();
+
+      this.set('value', newValue);
+      this.triggerAction({
+        action: this.get('valueEdited'),
+        actionContext: newValue
+      });
+      this.sendAction('on-change', {
+        event: event,
+        data: event.editor.getData()
+      });
+      this.trigger('valueChange', event.editor.getData());
+    } catch (e) {
+      Ember.logger.error("Error when handling scrivener change", e);
+    } finally {
+      this._editorChanging = false;
+    }
+  },
+  /**
+   * Private/test method to simulate pasting
+   * From ckeditor/tests/_benderjs/ckeditor/static/tools.js#emulatePaste
+   * @param content html that will be pasted into the document.
+   * @private
+   */
+  _paste: function (content) {
+    var ed = this._editor.editable();
+    ed.fire('paste', {
+      $: {
+        ctrlKey: true
+      }
+    });
+    ed.getDocument().$.execCommand('inserthtml', false, content);
   }
 });

--- a/addon/templates/components/ember-ckeditor.hbs
+++ b/addon/templates/components/ember-ckeditor.hbs
@@ -1,1 +1,1 @@
-{{textarea value=value class="editor"}}
+{{textarea class="editor"}}

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ module.exports = {
     this._super.included(app);
 
     app.import(app.bowerDirectory + '/ckeditor/ckeditor.js');
+    app.import(app.bowerDirectory + '/ckeditor/adapters/jquery.js');
   },
 
   contentFor: function(type, config) {

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -4,6 +4,7 @@
     "window",
     "location",
     "setTimeout",
+    "clearTimeout",
     "$",
     "-Promise",
     "define",

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -8,4 +8,4 @@ export default Ember.Controller.extend({
       this.set('text', newValue);
     }
   }
-})
+});

--- a/tests/unit/components/ember-ckeditor-test.js
+++ b/tests/unit/components/ember-ckeditor-test.js
@@ -1,4 +1,42 @@
 import { moduleForComponent, test } from 'ember-qunit';
+import Ember from 'ember';
+
+/**
+ * Some Test Helpers
+ *
+ */
+var waitForEvent = function (eventName) {
+  return function (editor) {
+    //console.log("waiting for Event", eventName);
+    return new Ember.RSVP.Promise(function (resolve, reject) {
+      editor.one(eventName, resolve);
+    });
+  };
+};
+var waitForAction = function (actionName) {
+  return function (editor) {
+    return new Ember.RSVP.Promise(function (resolve, reject) {
+      var target = { actionResolver: resolve };
+      editor.set(actionName, 'actionResolver');
+      editor.set('targetObject', target);
+    });
+
+  };
+};
+var waitForReady = waitForEvent('editor-ready');
+var waitForChange = waitForAction('on-change');
+var setValueOnEditor = function (editor, value) {
+    /**
+     * This is a little wierd to work with the sometimes-async nature of ckeditor.
+     * If it has loaded as an iframe, change events are async
+     * If it has loaded inline, changes are sync.
+     * So, we setup the promise before-hand, so we catch the event no matter what.
+     */
+    var promise = waitForChange(editor);
+    editor.set('value', value);
+    return promise;
+  };
+var component;
 
 moduleForComponent('ember-ckeditor', 'Unit | Component | ember ckeditor', {
   // Specify the other units that are required for this test
@@ -7,7 +45,7 @@ moduleForComponent('ember-ckeditor', 'Unit | Component | ember ckeditor', {
 });
 
 test('it renders', function(assert) {
-  assert.expect(2);
+  assert.expect(3);
 
   // Creates the component instance
   var component = this.subject();
@@ -16,4 +54,66 @@ test('it renders', function(assert) {
   // Renders the component to the page
   this.render();
   assert.equal(component._state, 'inDOM');
+  return waitForReady(component).then(function () {
+    assert.equal(component._editor.status, "ready");
+  });
+});
+
+
+
+test('it sends a "change" action on change', function (assert) {
+  assert.expect(1);
+  var component = this.subject();
+  this.render();
+  var timeout = setTimeout(function () {
+    assert.ok(false, "Test Timed Out, Action didn't fire");
+  }, 1000);
+  return waitForReady(component)
+    .then(function () {
+      return setValueOnEditor(component, "<p>Hi</p>");
+    })
+    .then(function (result) {
+      clearTimeout(timeout);
+      //FYI: ckeditor always adds a newline at the end of the output, so we trim() it to verify against input
+      assert.equal(result.data.trim(), "<p>Hi</p>", "Action was fired, result has the data we set");
+    });
+});
+
+
+test('it removes script and style tags', function (assert) {
+  assert.expect(2);
+
+  var component = this.subject();
+  this.render();
+
+  return waitForReady(component).then(function () {
+    var p = waitForChange(component);
+    component.set('value', "<p>Hi</p><script></script><style></style>");
+    return p;
+  })
+    .then(function () {
+      let value = component.get('value');
+      assert.equal(value.match(/script/), null);
+      assert.equal(value.match(/style/), null);
+    });
+
+});
+
+test('it can be re-rendered before the editor is finished initializing', function (assert) {
+  // ckeditor can't be destroyed before init has finished, otherwise it throws an exception.
+  // This makes certain that we don't throw an exception during normal ember re-rendering.
+  assert.expect(1);
+  var component = this.subject();
+
+  try {
+    Ember.run(() => {
+      this.render();
+      component.rerender();
+    });
+    assert.ok(true);
+  } catch (e) {
+    console.log(e.stack);
+    assert.ok(false, 'Exception thrown when re-rendering immediately');
+  }
+
 });


### PR DESCRIPTION
Adding in ability to data-bind, as well as more events/triggers.
Fixed an issue that can be caused when ember re-renders quickly.

Support setting the skin, as well as allowed/disallowed content.

I copied over my change handler from our private repo, and for the life of me, I can't remember why I need to use trigger, triggerAction and sendAction, but I remember needing all of them.
